### PR TITLE
including the json and hudi lambda monitoring set up

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -1,10 +1,23 @@
-module "monitoring" {
+module "monitoring_hudi" {
 
   source = "./monitoring"
 
   aws_region_name = var.aws_region
-  aws_account_id = data.aws_caller_identity.current.account_id
-  image_tag = "0.0.1"
-  database_name = "hudi"
-  table_name = "ticker_hudi_mor_ro"
+  aws_account_id  = data.aws_caller_identity.current.account_id
+  image_tag       = "0.0.1"
+  database_name   = "hudi"
+  table_name      = "hudi_benchmark_ro"
+  output_format   = "hudi"
+}
+
+module "monitoring_json" {
+
+  source = "./monitoring"
+
+  aws_region_name = var.aws_region
+  aws_account_id  = data.aws_caller_identity.current.account_id
+  image_tag       = "0.0.1"
+  database_name   = "hudi"
+  table_name      = "flink_output_json"
+  output_format   = "json"
 }

--- a/infra/monitoring/functions/metric_pusher/f_metric_pusher/env_variables.py
+++ b/infra/monitoring/functions/metric_pusher/f_metric_pusher/env_variables.py
@@ -1,4 +1,8 @@
 import os
 
-DATABASE_NAME = os.environ["DATABASE_NAME"]
-TABLE_NAME = os.environ["TABLE_NAME"]
+output_format = os.environ["OUTPUT_FORMAT"]
+
+db_table_names = {
+    "json": [os.environ["JSON_DATABASE_NAME"], os.environ["JSON_TABLE_NAME"]],
+    "hudi": [os.environ["HUDI_DATABASE_NAME"], os.environ["HUDI_TABLE_NAME"]],
+}

--- a/infra/monitoring/functions/metric_pusher/f_metric_pusher/main.py
+++ b/infra/monitoring/functions/metric_pusher/f_metric_pusher/main.py
@@ -1,24 +1,47 @@
 from f_metric_pusher.service import cloudwatch_service, athena_service
-from f_metric_pusher.queries import COUNT_QUERY
-from f_metric_pusher.env_variables import (
-    DATABASE_NAME,
-    TABLE_NAME,
-)
+from f_metric_pusher.queries import COUNT_QUERY, LATENCY_QUERY
+from f_metric_pusher.env_variables import db_table_names, output_format
 
 
-def main(event, context):
-    print("Starting metric pusher lambda")
-
-    query_result = athena_service.execute_query(
-        COUNT_QUERY.format(database_name=DATABASE_NAME, table_name=TABLE_NAME)
+def count_query_push_metric(metric_name, db_table_names):
+    count_query_result = athena_service.execute_query(
+        COUNT_QUERY.format(
+            database_name=db_table_names[output_format][0],
+            table_name=db_table_names[output_format][1],
+        )
     )
-    count_value = int(query_result[1]["Data"][0]["VarCharValue"])
 
     cloudwatch_service.push_metric(
         metric={
-            "metric_name": "hudi-json-benchmark",
-            "table_name": TABLE_NAME,
-            "value": count_value,
+            "metric_name": metric_name,
+            "table_name": db_table_names[output_format][1],
+            "value": count_query_result,
         }
     )
-    print("Finished metric pusher lambda")
+
+
+def latency_query_push_metric(metric_name, db_table_names):
+    count_query_result = athena_service.execute_query(
+        LATENCY_QUERY.format(
+            database_name=db_table_names[output_format][0],
+            table_name=db_table_names[output_format][1],
+        )
+    )
+
+    cloudwatch_service.push_metric(
+        metric={
+            "metric_name": metric_name,
+            "table_name": db_table_names[output_format][1],
+            "value": count_query_result,
+        }
+    )
+
+
+def main(event, context):
+    print("Starting", output_format, "pusher lambda")
+
+    count_query_push_metric(output_format + "_count", db_table_names)
+
+    latency_query_push_metric(output_format + "_count", db_table_names)
+
+    print("Finished", output_format, "pusher lambda")

--- a/infra/monitoring/functions/metric_pusher/f_metric_pusher/queries/latency.py
+++ b/infra/monitoring/functions/metric_pusher/f_metric_pusher/queries/latency.py
@@ -1,0 +1,5 @@
+LATENCY_QUERY = """
+    SELECT 
+            ROUND(avg(processing_time-event_time), 0) as processing_avg_ms
+    FROM {database_name}."{table_name}";
+"""

--- a/infra/monitoring/functions/metric_pusher/f_metric_pusher/queries/latency_hudi.py
+++ b/infra/monitoring/functions/metric_pusher/f_metric_pusher/queries/latency_hudi.py
@@ -1,0 +1,21 @@
+LATENCY_QUERY = """
+    SELECT 
+            ROUND(avg(processing_time-event_time), 0) as processing_avg_ms
+            , avg(TO_UNIXTIME(from_iso8601_timestamp(substring(_hoodie_commit_time, 1, 4) || '-' || 
+                                substring(_hoodie_commit_time, 5, 2) || '-' || 
+                                substring(_hoodie_commit_time, 7, 2) || 'T' || 
+                                substring(_hoodie_commit_time, 9, 2) || ':' || 
+                                substring(_hoodie_commit_time, 11, 2) || ':' || 
+                                substring(_hoodie_commit_time, 13, 2) || '.' || 
+                                substring(_hoodie_commit_time, 15, 3)))*1000 
+            - processing_time) AS commiting_avg_ms
+            , avg(TO_UNIXTIME(from_iso8601_timestamp(substring(_hoodie_commit_time, 1, 4) || '-' || 
+                                substring(_hoodie_commit_time, 5, 2) || '-' || 
+                                substring(_hoodie_commit_time, 7, 2) || 'T' || 
+                                substring(_hoodie_commit_time, 9, 2) || ':' || 
+                                substring(_hoodie_commit_time, 11, 2) || ':' || 
+                                substring(_hoodie_commit_time, 13, 2) || '.' || 
+                                substring(_hoodie_commit_time, 15, 3)))*1000 
+            - event_time) AS full_time_ms
+    FROM {database_name}."{table_name}";
+"""


### PR DESCRIPTION
Including the latency query

Updating the monitoring tf creating a specific module per monitoring (hudi and json)

Updating the lambda main script parameterizing the variables used (format, table, database,...)

Updated the env variables including the writting format and switching to a dict in order to use the variables in a more iterate way

Specific latency query included in case that we found the way of calculating the time when the json is written into s3, not just processed